### PR TITLE
Fix/source file align

### DIFF
--- a/include/ziso.h
+++ b/include/ziso.h
@@ -2,7 +2,7 @@
  */
 #define TITLE "ziso - ZSO compressor/decompressor"
 #define COPYR "Created by Daniel Carrasco (2023)"
-#define VERSI "0.1.0"
+#define VERSI "0.5.0"
 /*
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/ziso.cpp
+++ b/src/ziso.cpp
@@ -661,9 +661,11 @@ bool is_cdrom(std::fstream &fIn)
         if (
             std::strncmp(buffer.data(), (char *)cdSync, 12) != 0)
         {
+            fIn.seekg(currentPos);
             return false;
         }
     }
+    fIn.seekg(currentPos);
     return true;
 }
 


### PR DESCRIPTION
Fixed a bug introduced in the CD-ROM detection branch. The function was not going back to the start point causing a misalignment in the source data and therefore a corrupted compressed data.