### PR TITLE
Fix/decompression error block size 2352

### DIFF
--- a/include/ziso.h
+++ b/include/ziso.h
@@ -1,6 +1,6 @@
 #define TITLE "ziso - ZSO compressor/decompressor"
 #define COPYR "Created by Daniel Carrasco (2023)"
-#define VERSI "0.5.2"
+#define VERSI "0.6.1"
 
 #include "banner.h"
 #include <chrono>


### PR DESCRIPTION
Fixed a bug when the last block is smaller than the blocksizse, causing an error decompressing.